### PR TITLE
Focus on React

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    form_props (0.0.1)
+    form_props (0.0.2)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
       props_template (>= 0.23.0)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 ![Build Status](https://github.com/thoughtbot/form_props/actions/workflows/build.yml/badge.svg?branch=main)
 
-FormProps is a Rails form builder that outputs HTML attributes instead of tags.
-Now you can enjoy the conviences of Rails helpers in other view libraries like
-React, and React Native.
+FormProps is a Rails form builder that outputs HTML props instead of tags. Now
+you can enjoy the power and convenience of Rails helpers in React!
 
 By separting attributes from tags, FormProps can offer greater flexbility than normal
 Rails form builders; allowing designers to stay longer in HTML land and more easily
@@ -26,7 +25,7 @@ gem "form_props"
 and `bundle install`
 
 ## Usage
-`form_props` is designed to be used in a [PropsTemplate] template (it can work with 
+`form_props` is designed to be used in a [PropsTemplate] template (it can work with
 [jbuilder](#jbuilder)). For example in your `new.json.props`:
 
 ```ruby
@@ -46,7 +45,7 @@ would output
     props: {
       id: "create-post",
       action: "/posts/123",
-      accept-charset: "UTF-8",
+      acceptCharset: "UTF-8",
       method: "post"
     },
     extras: {
@@ -54,19 +53,19 @@ would output
         name: "_method",
         type: "hidden",
         defaultValue: "patch",
-        autocomplete: "off"
+        autoComplete: "off"
       },
       utf8: {
         name: "utf8",
         type: "hidden",
         defaultValue: "\u0026#x2713;",
-        autocomplete: "off"
+        autoComplete: "off"
       }
       csrf: {
         name: "utf8",
         type: "authenticity_token",
         defaultValue: "SomeTOken!23$",
-        autocomplete: "off"
+        autoComplete: "off"
       }
     },
     inputs: {
@@ -84,12 +83,11 @@ import React from 'react'
 
 export default ({props, inputs, extras}) => {
   <form {...props}>
-    {Object.values(extras).map((hiddenProps) => (<input {...hiddenProps} type="hidden"/>))}
+    {Object.values(extras).map((hiddenProps) => (<input {...hiddenProps} key={hiddenProps.name}/>))}
 
-    <input {...inputs.title} type="text"/>
+    <input {...inputs.title} />
     <label for={inputs.title.id}>Your Name</label>
-
-    <input {...inputs.submit} type="submit"/>
+    <button {...inputs.submit}>{inputs.submit.text}</button>
   </form>
 }
 ```
@@ -649,7 +647,7 @@ available.
 
 ## jbuilder
 
-form_props can work with jbuilder, but needs an extra call in the beginning of 
+form_props can work with jbuilder, but needs an extra call in the beginning of
 your template to `FormProps.set` to inject `json`. For example.
 
 ```ruby

--- a/components/CheckBox.js
+++ b/components/CheckBox.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 export default ({includeHidden = true, name=null, uncheckedValue=null, children, ...rest}) => {
   return (
     <>
-      {includeHidden && <input type="hidden" name={name} defaultValue={uncheckedValue} autocomplete="off" />}
+      {includeHidden && <input type="hidden" name={name} defaultValue={uncheckedValue} autoComplete="off" />}
       <input type="checkbox" name={name} {...rest}>
         {children}
       </input>

--- a/components/CollectionCheckBoxes.js
+++ b/components/CollectionCheckBoxes.js
@@ -21,7 +21,7 @@ export default ({includeHidden = true, collection=[], ...rest}) => {
 
   return (
     <>
-      {includeHidden && <input type="hidden" name={name} defaultValue={""} autocomplete="off" />}
+      {includeHidden && <input type="hidden" name={name} defaultValue={""} autoComplete="off" />}
       {checkboxes}
     </>
   )

--- a/components/CollectionRadioButtons.js
+++ b/components/CollectionRadioButtons.js
@@ -21,7 +21,7 @@ export default ({includeHidden = true, collection=[], ...rest}) => {
 
   return (
     <>
-      {includeHidden && <input type="hidden" name={name} defaultValue={""} autocomplete="off" />}
+      {includeHidden && <input type="hidden" name={name} defaultValue={""} autoComplete="off" />}
       {checkboxes}
     </>
   )

--- a/components/Select.js
+++ b/components/Select.js
@@ -17,7 +17,7 @@ export default ({includeHidden= true, name=null, id=null, children, options=[], 
 
   return (
     <>
-      {addHidden && <input type="hidden" disabled={disabled} name={name} value={""} autocomplete="off" />}
+      {addHidden && <input type="hidden" disabled={disabled} name={name} value={""} autoComplete="off" />}
       <select name={name} id={id} multiple={multiple} disabled={disabled} {...rest}>
         {children}
         {optionElements}

--- a/lib/form_props/action_view_extensions/form_helper.rb
+++ b/lib/form_props/action_view_extensions/form_helper.rb
@@ -40,6 +40,7 @@ module FormProps
         end
 
         html_options = html_options_for_form_with(url, model, **options)
+        html_options["acceptCharset"] ||= html_options.delete("accept-charset")
 
         json.extras do
           extra_props_for_form(json, html_options)
@@ -62,7 +63,7 @@ module FormProps
             json.name request_forgery_protection_token.to_s
             json.type "hidden"
             json.default_value token
-            json.autocomplete "off"
+            json.auto_complete "off"
           end
         end
       end
@@ -72,7 +73,7 @@ module FormProps
           json.name "_method"
           json.type "hidden"
           json.default_value method.to_s
-          json.autocomplete "off"
+          json.auto_complete "off"
         end
       end
 
@@ -81,7 +82,7 @@ module FormProps
           json.name "utf8"
           json.type "hidden"
           json.default_value "&#x2713;"
-          json.autocomplete "off"
+          json.auto_complete "off"
         end
       end
 

--- a/lib/form_props/form_builder.rb
+++ b/lib/form_props/form_builder.rb
@@ -132,7 +132,7 @@ module FormProps
     def submit(value = nil, options = {})
       value, options = nil, value if value.is_a?(Hash)
       value ||= submit_default_value
-      options = {name: "commit", value: value}.update(options)
+      options = {name: "commit", text: value}.update(options)
 
       Inputs::Submit.new(@template, options).render
     end

--- a/lib/form_props/inputs/hidden_field.rb
+++ b/lib/form_props/inputs/hidden_field.rb
@@ -4,7 +4,7 @@ module FormProps
   module Inputs
     class HiddenField < TextField
       def render
-        @options[:autocomplete] = "off"
+        @options[:auto_complete] = "off"
         super
       end
 

--- a/test/form_props_test.rb
+++ b/test/form_props_test.rb
@@ -22,13 +22,13 @@ class FormPropsTest < ActionView::TestCase
           name: "utf8",
           type: "hidden",
           defaultValue: "&#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
         enctype: "multipart/form-data",
         action: "http://www.example.com",
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -47,18 +47,18 @@ class FormPropsTest < ActionView::TestCase
           name: "_method",
           type: "hidden",
           defaultValue: "patch",
-          autocomplete: "off"
+          autoComplete: "off"
         },
         utf8: {
           name: "utf8",
           type: "hidden",
           defaultValue: "&#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
         action: "http://www.example.com",
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -77,18 +77,18 @@ class FormPropsTest < ActionView::TestCase
           name: "_method",
           type: "hidden",
           defaultValue: "put",
-          autocomplete: "off"
+          autoComplete: "off"
         },
         utf8: {
           name: "utf8",
           type: "hidden",
           defaultValue: "&#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
         action: "http://www.example.com",
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -107,18 +107,18 @@ class FormPropsTest < ActionView::TestCase
           name: "_method",
           type: "hidden",
           defaultValue: "delete",
-          autocomplete: "off"
+          autoComplete: "off"
         },
         utf8: {
           name: "utf8",
           type: "hidden",
           defaultValue: "&#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
         action: "http://www.example.com",
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -135,11 +135,11 @@ class FormPropsTest < ActionView::TestCase
           name: "utf8",
           type: "hidden",
           defaultValue: "&#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -157,11 +157,11 @@ class FormPropsTest < ActionView::TestCase
           name: "utf8",
           type: "hidden",
           defaultValue: "&#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -177,7 +177,7 @@ class FormPropsTest < ActionView::TestCase
       extras: {},
       props: {
         action: "http://www.example.com",
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -193,7 +193,7 @@ class FormPropsTest < ActionView::TestCase
         extras: {},
         props: {
           action: "http://www.example.com",
-          "accept-charset": "UTF-8",
+          acceptCharset: "UTF-8",
           method: "post"
         }
       }.to_json
@@ -213,12 +213,12 @@ class FormPropsTest < ActionView::TestCase
             name: "utf8",
             type: "hidden",
             defaultValue: "&#x2713;",
-            autocomplete: "off"
+            autoComplete: "off"
           }
         },
         props: {
           action: "http://www.example.com",
-          "accept-charset": "UTF-8",
+          acceptCharset: "UTF-8",
           method: "post"
         }
       }.to_json
@@ -277,19 +277,19 @@ class FormPropsTest < ActionView::TestCase
           name: "_method",
           type: "hidden",
           defaultValue: "patch",
-          autocomplete: "off"
+          autoComplete: "off"
         },
         utf8: {
           name: "utf8",
           type: "hidden",
           defaultValue: "\u0026#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
         id: "create-post",
         action: "/posts/123",
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json
@@ -345,19 +345,19 @@ class FormPropsTest < ActionView::TestCase
           name: "_method",
           type: "hidden",
           defaultValue: "patch",
-          autocomplete: "off"
+          autoComplete: "off"
         },
         utf8: {
           name: "utf8",
           type: "hidden",
           defaultValue: "\u0026#x2713;",
-          autocomplete: "off"
+          autoComplete: "off"
         }
       },
       props: {
         id: "create-post",
         action: "/posts/123",
-        "accept-charset": "UTF-8",
+        acceptCharset: "UTF-8",
         method: "post"
       }
     }.to_json

--- a/test/inputs/hidden_field_test.rb
+++ b/test/inputs/hidden_field_test.rb
@@ -16,7 +16,7 @@ class HiddenFieldTest < ActionView::TestCase
       "defaultValue" => "Hello World",
       "name" => "post[title]",
       "id" => "post_title",
-      "autocomplete" => "off"
+      "autoComplete" => "off"
     }
 
     assert_equal(JSON.parse(result)["inputs"]["title"], expected)
@@ -31,7 +31,7 @@ class HiddenFieldTest < ActionView::TestCase
       "defaultValue" => "1",
       "name" => "post[secret]",
       "id" => "post_secret",
-      "autocomplete" => "off"
+      "autoComplete" => "off"
     }
 
     assert_equal(JSON.parse(result)["inputs"]["secret"], expected)
@@ -48,14 +48,14 @@ class HiddenFieldTest < ActionView::TestCase
       "type" => "hidden",
       "name" => "post[title]",
       "id" => "post_title",
-      "autocomplete" => "off"
+      "autoComplete" => "off"
     }
     assert_equal(JSON.parse(result)["inputs"]["title"], expected)
   end
 
   def test_hidden_field_with_options
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="hidden" value="Something Else" autocomplete="off" />',
+      '<input id="post_title" name="post[title]" type="hidden" value="Something Else" autoComplete="off" />',
       hidden_field("post", "title", value: "Something Else")
     )
     @post.title = nil
@@ -69,7 +69,7 @@ class HiddenFieldTest < ActionView::TestCase
       "name" => "post[title]",
       "defaultValue" => "Something Else",
       "id" => "post_title",
-      "autocomplete" => "off"
+      "autoComplete" => "off"
     }
     assert_equal(JSON.parse(result)["inputs"]["title"], expected)
   end

--- a/test/inputs/submit_test.rb
+++ b/test/inputs/submit_test.rb
@@ -17,7 +17,7 @@ class SubmitTest < ActionView::TestCase
 
         expected = {
           "type" => "submit",
-          "defaultValue" => "Create Post",
+          "text" => "Create Post",
           "name" => "commit"
         }
 
@@ -36,7 +36,7 @@ class SubmitTest < ActionView::TestCase
 
       expected = {
         "type" => "submit",
-        "defaultValue" => "Confirm Post changes",
+        "text" => "Confirm Post changes",
         "name" => "commit"
       }
 
@@ -55,7 +55,7 @@ class SubmitTest < ActionView::TestCase
 
       expected = {
         "type" => "submit",
-        "defaultValue" => "Save changes",
+        "text" => "Save changes",
         "name" => "commit"
       }
 
@@ -72,7 +72,7 @@ class SubmitTest < ActionView::TestCase
 
       expected = {
         "type" => "submit",
-        "defaultValue" => "Update your Post",
+        "text" => "Update your Post",
         "name" => "commit"
       }
 
@@ -92,7 +92,7 @@ class SubmitTest < ActionView::TestCase
 
       expected = {
         "type" => "submit",
-        "defaultValue" => "Update your Post",
+        "text" => "Update your Post",
         "name" => "commit"
       }
 

--- a/test/inputs/text_area_test.rb
+++ b/test/inputs/text_area_test.rb
@@ -153,10 +153,10 @@ class TextAreaTest < ActionView::TestCase
         ]
       },
       "extras" => {
-        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autocomplete" => "off"},
-        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autocomplete" => "off"}
+        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
+        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "accept-charset" => "UTF-8", "method" => "post"}
+      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)
@@ -187,10 +187,10 @@ class TextAreaTest < ActionView::TestCase
         ]
       },
       "extras" => {
-        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autocomplete" => "off"},
-        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autocomplete" => "off"}
+        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
+        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "accept-charset" => "UTF-8", "method" => "post"}
+      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)

--- a/test/inputs/text_field_test.rb
+++ b/test/inputs/text_field_test.rb
@@ -153,10 +153,10 @@ class TextFieldTest < ActionView::TestCase
         ]
       },
       "extras" => {
-        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autocomplete" => "off"},
-        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autocomplete" => "off"}
+        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
+        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "accept-charset" => "UTF-8", "method" => "post"}
+      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)
@@ -187,10 +187,10 @@ class TextFieldTest < ActionView::TestCase
         ]
       },
       "extras" => {
-        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autocomplete" => "off"},
-        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autocomplete" => "off"}
+        "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
+        "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "accept-charset" => "UTF-8", "method" => "post"}
+      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)


### PR DESCRIPTION
This commit changes `accept-charset` to `acceptCharset` and `auto-complete` to `autoComplete`. We also have the submit helper props expect to use a submit button instead of an input, because React doesn't have a `defaultValue` prop for `<input type="submit">`.

Generally, i'm deciding to target exclusively on React for now. I think we can fix these for HTML someday.