### PR TITLE
Add ability to explicitly set a key

### DIFF
--- a/lib/form_props/inputs/base.rb
+++ b/lib/form_props/inputs/base.rb
@@ -11,13 +11,15 @@ module FormProps
         options = options.with_indifferent_access
 
         @controlled = options.delete(:controlled)
+        @key = options.delete(:key)
+
         super(object_name, method_name, template_object, options)
       end
 
       private
 
       def sanitized_key
-        sanitized_method_name.camelize(:lower)
+        @key || sanitized_method_name.camelize(:lower)
       end
 
       def add_options(option_tags, options, value = nil)

--- a/lib/form_props/inputs/radio_button.rb
+++ b/lib/form_props/inputs/radio_button.rb
@@ -22,8 +22,6 @@ module FormProps
         @options[:value] = @tag_value
         @options[:checked] = true if input_checked?(@options)
 
-        name_for_key = (sanitized_method_name + "_#{sanitized_value(@tag_value)}").camelize(:lower)
-
         body_block = -> {
           add_default_name_and_id_for_value(@tag_value, @options)
           input_props(@options)
@@ -32,13 +30,17 @@ module FormProps
         if flatten
           body_block.call
         else
-          json.set!(name_for_key) do
+          json.set!(sanitized_key) do
             body_block.call
           end
         end
       end
 
       private
+
+      def sanitized_key
+        @key || (sanitized_method_name + "_#{sanitized_value(@tag_value)}").camelize(:lower)
+      end
 
       def checked?(value)
         value.to_s == @tag_value.to_s

--- a/test/form_props_test.rb
+++ b/test/form_props_test.rb
@@ -364,6 +364,75 @@ class FormPropsTest < ActionView::TestCase
     assert_equal(result, expected)
   end
 
+  def test_form_with_explicit_key
+    form_props(model: @post, id: "create-post") do |f|
+      f.text_field(:title, key: :aTitle)
+      f.text_area(:body, key: :aBody)
+      f.check_box(:secret, key: :aSecret)
+      f.select(:category, %w[animal economy sports], key: :aCategory)
+    end
+
+    result = json.result!.strip
+
+    expected = {
+      inputs: {
+        aTitle: {
+          type: "text",
+          defaultValue: "Hello World",
+          name: "post[title]",
+          id: "post_title"
+        },
+        aBody: {
+          name: "post[body]",
+          id: "post_body",
+          type: "textarea",
+          defaultValue: "Back to the hill and over it again!"
+        },
+        aSecret: {
+          type: "checkbox",
+          defaultValue: "1",
+          defaultChecked: true,
+          uncheckedValue: "0",
+          includeHidden: true,
+          name: "post[secret]",
+          id: "post_secret"
+        },
+        aCategory: {
+          name: "post[category]",
+          id: "post_category",
+          type: "select",
+          options: [
+            {value: "animal", label: "animal"},
+            {value: "economy", label: "economy"},
+            {value: "sports", label: "sports"}
+          ]
+        }
+      },
+      extras: {
+        method: {
+          name: "_method",
+          type: "hidden",
+          defaultValue: "patch",
+          autoComplete: "off"
+        },
+        utf8: {
+          name: "utf8",
+          type: "hidden",
+          defaultValue: "\u0026#x2713;",
+          autoComplete: "off"
+        }
+      },
+      props: {
+        id: "create-post",
+        action: "/posts/123",
+        acceptCharset: "UTF-8",
+        method: "post"
+      }
+    }.to_json
+    assert_equal(result, expected)
+  end
+
+
   def with_default_enforce_utf8(value)
     old_value = ActionView::Helpers::FormTagHelper.default_enforce_utf8
     ActionView::Helpers::FormTagHelper.default_enforce_utf8 = value


### PR DESCRIPTION
form_props autocamelizes keys, but sometimes we'd like to be explicit. This adds the option to set the key and skip camelize.