### PR TITLE
Add camelize to association_key

### DIFF
--- a/lib/form_props/form_builder.rb
+++ b/lib/form_props/form_builder.rb
@@ -139,6 +139,7 @@ module FormProps
 
     def fields_for_with_nested_attributes(association_name, association, options, block)
       name = "#{object_name}[#{association_name}_attributes]"
+      association_key = "#{association_name.to_s.camelize(:lower)}Attributes"
       association = convert_to_model(association)
       json = @template.instance_variable_get(:@__json)
 
@@ -151,7 +152,7 @@ module FormProps
       if association.respond_to?(:to_ary)
         explicit_child_index = options[:child_index]
 
-        json.set!("#{association_name}Attributes") do
+        json.set!(association_key) do
           json.array! association do |child|
             if explicit_child_index
               options[:child_index] = explicit_child_index.call if explicit_child_index.respond_to?(:call)
@@ -163,7 +164,7 @@ module FormProps
           end
         end
       elsif association
-        json.set!("#{association_name}Attributes") do
+        json.set!(association_key) do
           fields_for_nested_model(name, association, options, block)
         end
       end


### PR DESCRIPTION
With a recent change to make key formatting explicit in props_template. Keys are [autocamelized] in form_props, but when using fields_for, the keys were not properly formatted. This change make it so that `fields_for` will also camelize the keys.

[autocamelized]: https://github.com/thoughtbot/form_props/commit/2c5ebd0d28ce91d88b7f659ac8573a5009c75d0b