### PR TITLE
Use `text_field` in usage example of `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and `bundle install`
 ```ruby
 json.some_form do
   form_props(@post) do |f|
-    f.text :title
+    f.text_field :title
     f.submit
   end
 end


### PR DESCRIPTION
`FormProps::FormBuilder` uses `text_field` and not `text` so this just updates the one case where that wasn't reflected. Other locations in the `README.md` look to be correct.