### PR TITLE
Pass `form_props` options to `Inputs::RadioButton`

### DIFF
--- a/lib/form_props/form_builder.rb
+++ b/lib/form_props/form_builder.rb
@@ -102,7 +102,7 @@ module FormProps
     end
 
     def radio_button(method, tag_value, options = {})
-      Inputs::RadioButton.new(@object_name, method, @template, tag_value, options).render
+      Inputs::RadioButton.new(@object_name, method, @template, tag_value, objectify_options(options)).render
     end
 
     def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})

--- a/test/form_props_test.rb
+++ b/test/form_props_test.rb
@@ -302,6 +302,7 @@ class FormPropsTest < ActionView::TestCase
       f.text_area(:body)
       f.check_box(:secret)
       f.select(:category, %w[animal economy sports])
+      f.radio_button(:admin, true)
     end
 
     result = json.result!.strip
@@ -338,6 +339,13 @@ class FormPropsTest < ActionView::TestCase
             {value: "economy", label: "economy"},
             {value: "sports", label: "sports"}
           ]
+        },
+        adminTrue: {
+          type: "radio",
+          value: "true",
+          checked: true,
+          name: "post[admin]",
+          id: "post_admin_true"
         }
       },
       extras: {


### PR DESCRIPTION
In order to access inherited options like `controlled`, we need to pass down the options given to `form_props` to the `Inputs::RadioButton` we create inside of the `radio_button` helper.

This tweaks that helper to call `objectify_options` similar to how the other helpers do. The `test_form_with_using_controlled_option` test was then modified to exercise this helper in order to confirm the change.

Closes #14 