### PR TITLE
Rename `props` to `form`

### DIFF
--- a/lib/form_props/action_view_extensions/form_helper.rb
+++ b/lib/form_props/action_view_extensions/form_helper.rb
@@ -45,7 +45,7 @@ module FormProps
           extra_props_for_form(json, html_options)
         end
 
-        json.props(FormProps::Helper.format_keys(html_options))
+        json.form(FormProps::Helper.format_keys(html_options))
       end
 
       private

--- a/test/form_props_test.rb
+++ b/test/form_props_test.rb
@@ -25,7 +25,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         encType: "multipart/form-data",
         action: "http://www.example.com",
         acceptCharset: "UTF-8",
@@ -56,7 +56,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         action: "http://www.example.com",
         acceptCharset: "UTF-8",
         method: "post"
@@ -86,7 +86,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         action: "http://www.example.com",
         acceptCharset: "UTF-8",
         method: "post"
@@ -116,7 +116,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         action: "http://www.example.com",
         acceptCharset: "UTF-8",
         method: "post"
@@ -138,7 +138,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         acceptCharset: "UTF-8",
         method: "post"
       }
@@ -160,7 +160,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         acceptCharset: "UTF-8",
         method: "post"
       }
@@ -175,7 +175,7 @@ class FormPropsTest < ActionView::TestCase
 
     expected = {
       extras: {},
-      props: {
+      form: {
         action: "http://www.example.com",
         acceptCharset: "UTF-8",
         method: "post"
@@ -191,7 +191,7 @@ class FormPropsTest < ActionView::TestCase
       form_props
       expected = {
         extras: {},
-        props: {
+        form: {
           action: "http://www.example.com",
           acceptCharset: "UTF-8",
           method: "post"
@@ -216,7 +216,7 @@ class FormPropsTest < ActionView::TestCase
             autoComplete: "off"
           }
         },
-        props: {
+        form: {
           action: "http://www.example.com",
           acceptCharset: "UTF-8",
           method: "post"
@@ -286,7 +286,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         id: "create-post",
         action: "/posts/123",
         acceptCharset: "UTF-8",
@@ -362,7 +362,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         id: "create-post",
         action: "/posts/123",
         acceptCharset: "UTF-8",
@@ -430,7 +430,7 @@ class FormPropsTest < ActionView::TestCase
           autoComplete: "off"
         }
       },
-      props: {
+      form: {
         id: "create-post",
         action: "/posts/123",
         acceptCharset: "UTF-8",

--- a/test/inputs/text_area_test.rb
+++ b/test/inputs/text_area_test.rb
@@ -156,7 +156,7 @@ class TextAreaTest < ActionView::TestCase
         "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
         "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
+      "form" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)
@@ -190,7 +190,7 @@ class TextAreaTest < ActionView::TestCase
         "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
         "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
+      "form" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)

--- a/test/inputs/text_field_test.rb
+++ b/test/inputs/text_field_test.rb
@@ -156,7 +156,7 @@ class TextFieldTest < ActionView::TestCase
         "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
         "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
+      "form" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)
@@ -190,7 +190,7 @@ class TextFieldTest < ActionView::TestCase
         "utf8" => {"name" => "utf8", "type" => "hidden", "defaultValue" => "&#x2713;", "autoComplete" => "off"},
         "method" => {"name" => "_method", "type" => "hidden", "defaultValue" => "patch", "autoComplete" => "off"}
       },
-      "props" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
+      "form" => {"action" => "/posts/123", "acceptCharset" => "UTF-8", "method" => "post"}
     }
 
     assert_equal(JSON.parse(result), expected)


### PR DESCRIPTION
The naming of the key has caused confusion. This PR changes the key name so its easier to destructure on the react side:

```
const {form, inputs, extras} = someFormProps

<form {...form} />
```