### PR TITLE
Fix checkbox and radiobutton checked.

### DIFF
--- a/lib/form_props/inputs/base.rb
+++ b/lib/form_props/inputs/base.rb
@@ -24,6 +24,7 @@ module FormProps
 
       def input_props(options)
         return if options.blank?
+        # tag_type = options[:type]
 
         options.each_pair do |key, value|
           type = TAG_TYPES[key]
@@ -68,10 +69,12 @@ module FormProps
           value = value.source
         end
 
+        is_checkable = respond_to?(:field_type, true) && (field_type == "checkbox" || field_type == "radio")
+
         @controlled ||= nil
 
         if !@controlled
-          if key.to_sym == :value
+          if key.to_sym == :value && !is_checkable
             key = "default_value"
           end
 

--- a/lib/form_props/inputs/check_box.rb
+++ b/lib/form_props/inputs/check_box.rb
@@ -20,9 +20,9 @@ module FormProps
 
       def render(flatten = false)
         options = @options.stringify_keys
-        options[:type] = "checkbox"
+        options[:type] = field_type
         options[:value] = @checked_value
-        options[:checked] = true if input_checked?(options)
+        options[:checked] = input_checked?(options)
         options[:unchecked_value] = @unchecked_value || ""
         options[:include_hidden] = options.fetch(:include_hidden) { true }
 
@@ -47,6 +47,10 @@ module FormProps
       end
 
       private
+
+      def field_type
+        "checkbox"
+      end
 
       def checked?(value)
         case value

--- a/lib/form_props/inputs/collection_select.rb
+++ b/lib/form_props/inputs/collection_select.rb
@@ -30,6 +30,12 @@ module FormProps
           @options, @html_options
         )
       end
+
+      private
+
+      def field_type
+        "select"
+      end
     end
   end
 end

--- a/lib/form_props/inputs/grouped_collection_select.rb
+++ b/lib/form_props/inputs/grouped_collection_select.rb
@@ -31,6 +31,12 @@ module FormProps
           option_groups_from_collection_for_select(@collection, @group_method, @group_label_method, @option_key_method, @option_value_method, option_tags_options), @options, @html_options
         )
       end
+
+      private
+
+      def field_type
+        "select"
+      end
     end
   end
 end

--- a/lib/form_props/inputs/radio_button.rb
+++ b/lib/form_props/inputs/radio_button.rb
@@ -18,7 +18,7 @@ module FormProps
       end
 
       def render(flatten = false)
-        @options[:type] = "radio"
+        @options[:type] = field_type
         @options[:value] = @tag_value
         @options[:checked] = true if input_checked?(@options)
 
@@ -37,6 +37,11 @@ module FormProps
       end
 
       private
+
+      def field_type
+        "radio"
+      end
+
 
       def sanitized_key
         @key || (sanitized_method_name + "_#{sanitized_value(@tag_value)}").camelize(:lower)

--- a/lib/form_props/inputs/select.rb
+++ b/lib/form_props/inputs/select.rb
@@ -35,6 +35,10 @@ module FormProps
 
       private
 
+      def field_type
+        "select"
+      end
+
       # Grouped choices look like this:
       #
       #   [nil, []]

--- a/lib/form_props/inputs/time_zone_select.rb
+++ b/lib/form_props/inputs/time_zone_select.rb
@@ -22,6 +22,12 @@ module FormProps
           time_zone_options_for_select(value || @options[:default], @priority_zones, @options[:model] || ActiveSupport::TimeZone), @options, @html_options
         )
       end
+
+      private
+
+      def field_type
+        "select"
+      end
     end
   end
 end

--- a/lib/form_props/inputs/weekday_select.rb
+++ b/lib/form_props/inputs/weekday_select.rb
@@ -28,6 +28,12 @@ module FormProps
           @html_options
         )
       end
+
+      private
+
+      def field_type
+        "select"
+      end
     end
   end
 end

--- a/lib/form_props/select_renderer.rb
+++ b/lib/form_props/select_renderer.rb
@@ -30,7 +30,7 @@ module FormProps
         options[:include_blank] ||= true unless options[:prompt]
       end
 
-      html_options["type"] = "select"
+      html_options["type"] = field_type
       value_for_blank = options.fetch(:selected) { value }
       option_tags = add_options(option_tags, options, value_for_blank)
 

--- a/test/form_props_test.rb
+++ b/test/form_props_test.rb
@@ -263,7 +263,7 @@ class FormPropsTest < ActionView::TestCase
         },
         secret: {
           type: "checkbox",
-          defaultValue: "1",
+          value: "1",
           defaultChecked: true,
           uncheckedValue: "0",
           includeHidden: true,
@@ -407,7 +407,7 @@ class FormPropsTest < ActionView::TestCase
         },
         aSecret: {
           type: "checkbox",
-          defaultValue: "1",
+          value: "1",
           defaultChecked: true,
           uncheckedValue: "0",
           includeHidden: true,

--- a/test/inputs/checkbox_field_test.rb
+++ b/test/inputs/checkbox_field_test.rb
@@ -13,8 +13,9 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "1",
+      "value" => "1",
       "uncheckedValue" => "0",
+      "defaultChecked" => false,
       "includeHidden" => true,
       "name" => "post[admin]",
       "id" => "post_admin"
@@ -41,7 +42,8 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "1",
+      "value" => "1",
+      "defaultChecked" => false,
       "uncheckedValue" => "0",
       "disabled" => true,
       "includeHidden" => true,
@@ -60,7 +62,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "1",
+      "value" => "1",
       "uncheckedValue" => "0",
       "defaultChecked" => true,
       "includeHidden" => true,
@@ -78,7 +80,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "1",
+      "value" => "1",
       "defaultChecked" => true,
       "uncheckedValue" => "0",
       "includeHidden" => true,
@@ -106,8 +108,9 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "1",
+      "value" => "1",
       "uncheckedValue" => "0",
+      "defaultChecked" => false,
       "includeHidden" => true,
       "name" => "post[secret]",
       "id" => "post_secret"
@@ -167,8 +170,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "1")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "1")
 
     @post.admin = ["1"]
     form_props(model: @post) do |f|
@@ -177,7 +180,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "1")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "1")
 
     @post.admin = Set.new(["1"])
     form_props(model: @post) do |f|
@@ -186,7 +189,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "1")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "1")
   end
 
   def test_check_box_with_include_hidden_false
@@ -197,7 +200,8 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "1",
+      "value" => "1",
+      "defaultChecked" => false,
       "includeHidden" => false,
       "uncheckedValue" => "0",
       "name" => "post[secret]",
@@ -224,7 +228,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "on")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "on")
 
     @post.admin = "off"
     form_props(model: @post) do |f|
@@ -232,8 +236,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "on")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "on")
   end
 
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
@@ -244,7 +248,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "false")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "false")
 
     @post.admin = true
     form_props(model: @post) do |f|
@@ -252,8 +256,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "false")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "false")
   end
 
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_integer
@@ -264,7 +268,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
 
     @post.admin = 1
     form_props(model: @post) do |f|
@@ -272,8 +276,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
 
     @post.admin = 2
     form_props(model: @post) do |f|
@@ -281,8 +285,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
   end
 
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_float
@@ -293,7 +297,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
 
     @post.admin = 1.1
     form_props(model: @post) do |f|
@@ -301,8 +305,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
 
     @post.admin = 2.2
     form_props(model: @post) do |f|
@@ -310,8 +314,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
   end
 
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_big_decimal
@@ -322,7 +326,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
 
     @post.admin = BigDecimal("1")
     form_props(model: @post) do |f|
@@ -330,8 +334,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
 
     @post.admin = BigDecimal("2.2", 1)
     form_props(model: @post) do |f|
@@ -339,8 +343,8 @@ class CheckboxFieldTest < ActionView::TestCase
     end
     result = json.result!.strip
 
-    assert_nil(JSON.parse(result)["inputs"]["admin"]["defaultChecked"])
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "0")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], false)
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "0")
   end
 
   def test_check_box_with_nil_unchecked_value
@@ -351,7 +355,7 @@ class CheckboxFieldTest < ActionView::TestCase
     result = json.result!.strip
 
     assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultChecked"], true)
-    assert_equal(JSON.parse(result)["inputs"]["admin"]["defaultValue"], "on")
+    assert_equal(JSON.parse(result)["inputs"]["admin"]["value"], "on")
   end
 
   def test_check_box_with_multiple_behavior
@@ -364,7 +368,8 @@ class CheckboxFieldTest < ActionView::TestCase
 
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "1",
+      "value" => "1",
+      "defaultChecked" => false,
       "uncheckedValue" => "0",
       "includeHidden" => true,
       "name" => "post[comment_ids][]",
@@ -380,7 +385,7 @@ class CheckboxFieldTest < ActionView::TestCase
 
     expected = {
       "type" => "checkbox",
-      "defaultValue" => "3",
+      "value" => "3",
       "defaultChecked" => true,
       "uncheckedValue" => "0",
       "includeHidden" => true,

--- a/test/inputs/radio_button_test.rb
+++ b/test/inputs/radio_button_test.rb
@@ -13,7 +13,7 @@ class RadioButtonTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "radio",
-      "defaultValue" => "Hello World",
+      "value" => "Hello World",
       "defaultChecked" => true,
       "name" => "post[title]",
       "id" => "post_title_hello_world"
@@ -26,7 +26,7 @@ class RadioButtonTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "radio",
-      "defaultValue" => "Goodbye World",
+      "value" => "Goodbye World",
       "name" => "post[title]",
       "id" => "post_title_goodbye_world"
     }
@@ -41,7 +41,7 @@ class RadioButtonTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "radio",
-      "defaultValue" => "1",
+      "value" => "1",
       "defaultChecked" => true,
       "name" => "post[admin]",
       "id" => "post_admin_1"
@@ -57,7 +57,7 @@ class RadioButtonTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "radio",
-      "defaultValue" => "-1",
+      "value" => "-1",
       "defaultChecked" => true,
       "name" => "post[admin]",
       "id" => "post_admin_-1"
@@ -73,7 +73,7 @@ class RadioButtonTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "radio",
-      "defaultValue" => "1",
+      "value" => "1",
       "defaultChecked" => true,
       "name" => "post[admin]",
       "id" => "foo"
@@ -89,7 +89,7 @@ class RadioButtonTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "radio",
-      "defaultValue" => "true",
+      "value" => "true",
       "name" => "post[admin]",
       "id" => "post_admin_true"
     }
@@ -102,7 +102,7 @@ class RadioButtonTest < ActionView::TestCase
     result = json.result!.strip
     expected = {
       "type" => "radio",
-      "defaultValue" => "false",
+      "value" => "false",
       "name" => "post[admin]",
       "id" => "post_admin_false"
     }

--- a/test/inputs/select_test.rb
+++ b/test/inputs/select_test.rb
@@ -835,6 +835,32 @@ class SelectTest < ActionView::TestCase
       output
     )
   end
+ 
+  def test_select_with_array_of_one_value
+    @continent = Continent.new
+    @continent.countries = "Africa"
+
+    form_props(model: @continent) do |f|
+      f.select(:countries, %W[Africa Europe America], {multiple: true})
+    end
+
+    result = json.result!.strip
+
+    expected = {
+      "type" => "select",
+      "name" => "continent[countries]",
+      "id" => "continent_countries",
+      "multiple" => true,
+      "defaultValue" => ["Africa"],
+      "options" => [
+        {"value" => "Africa", "label" => "Africa"},
+        {"value" => "Europe", "label" => "Europe"},
+        {"value" => "America", "label" => "America"}
+      ]
+    }
+
+    assert_equal(JSON.parse(result)["inputs"]["countries"], expected)
+  end
 
   def test_required_select
     @post = Post.new


### PR DESCRIPTION
These will never need a `defaultValue`, instead, React expected a `value` and uses defaultChecked or `checked` control the value.