### PR TITLE
Fix undefined method `add_default_name_and_id`

### DIFF
--- a/lib/form_props/inputs/base.rb
+++ b/lib/form_props/inputs/base.rb
@@ -3,6 +3,12 @@
 module FormProps
   module Inputs
     class Base < ::ActionView::Helpers::Tags::Base
+      # Remove when no longer supporting Rails 7
+      if ActionView::VERSION::STRING < "8"
+        alias_method :add_default_name_and_field_for_value, :add_default_name_and_id_for_value
+        alias_method :add_default_name_and_field, :add_default_name_and_id
+      end
+
       def json
         @json ||= @template_object.instance_variable_get(:@__json)
       end
@@ -13,7 +19,7 @@ module FormProps
         @controlled = options.delete(:controlled)
         @key = options.delete(:key)
 
-        super(object_name, method_name, template_object, options)
+        super
       end
 
       private

--- a/lib/form_props/inputs/check_box.rb
+++ b/lib/form_props/inputs/check_box.rb
@@ -28,10 +28,10 @@ module FormProps
 
         body_block = -> {
           if options[:multiple]
-            add_default_name_and_id_for_value(@checked_value, options)
+            add_default_name_and_field_for_value(@checked_value, options)
             options.delete(:multiple)
           else
-            add_default_name_and_id(options)
+            add_default_name_and_field(options)
           end
 
           input_props(options)

--- a/lib/form_props/inputs/radio_button.rb
+++ b/lib/form_props/inputs/radio_button.rb
@@ -23,7 +23,7 @@ module FormProps
         @options[:checked] = true if input_checked?(@options)
 
         body_block = -> {
-          add_default_name_and_id_for_value(@tag_value, @options)
+          add_default_name_and_field_for_value(@tag_value, @options)
           input_props(@options)
         }
 

--- a/lib/form_props/inputs/text_area.rb
+++ b/lib/form_props/inputs/text_area.rb
@@ -9,7 +9,7 @@ module FormProps
 
       def render
         json.set!(sanitized_key) do
-          add_default_name_and_id(@options)
+          add_default_name_and_field(@options)
           @options[:type] ||= field_type
           @options[:value] = @options.fetch(:value) { value_before_type_cast }
 

--- a/lib/form_props/inputs/text_field.rb
+++ b/lib/form_props/inputs/text_field.rb
@@ -13,7 +13,7 @@ module FormProps
         @options[:value] = @options.fetch(:value) { value_before_type_cast } unless field_type == "file"
 
         json.set!(sanitized_key) do
-          add_default_name_and_id(@options)
+          add_default_name_and_field(@options)
           input_props(@options)
         end
       end

--- a/lib/form_props/select_renderer.rb
+++ b/lib/form_props/select_renderer.rb
@@ -23,7 +23,7 @@ module FormProps
 
     def select_content_props(option_tags, options, html_options)
       html_options = html_options.stringify_keys
-      add_default_name_and_id(html_options)
+      add_default_name_and_field(html_options)
 
       if placeholder_required?(html_options)
         raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false


### PR DESCRIPTION
This resolves https://github.com/thoughtbot/form_props/issues/26, by using Rails 8 methods, but aliasing for Rails 7 compatibility.

A CI run should update to 8.0.3 where the error happened, and test older for Rails 7.